### PR TITLE
correct jitsi videobridge service name

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,7 @@
 jitsi_meet_server_name: "meet.example.com"
 jitsi_meet_videobridge_loglevel: "ERROR"
 jitsi_meet_videobridge_secret: "CHANGEME"
+jitsi_meet_videobridge_service: "jitsi-videobridge2"
 jitsi_meet_videobridge_port: 5347
 jitsi_meet_jicofo_loglevel: "ERROR"
 jitsi_meet_jicofo_user: focus

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -12,15 +12,10 @@
 
 - name: restart jitsi-videobridge
   service:
-    name: jitsi-videobridge
+    name: "{{ jitsi_meet_videobridge_service }}"
     state: restarted
 
 - name: restart jicofo
   service:
     name: jicofo
-    state: restarted
-
-- name: restart jitsi-videobridge
-  service:
-    name: jitsi-videobridge
     state: restarted

--- a/tasks/jitsi-meet.yml
+++ b/tasks/jitsi-meet.yml
@@ -70,7 +70,7 @@
 
 - name: Enable jitsi-videobridge
   service:
-    name: jitsi-videobridge
+    name: "{{ jitsi_meet_videobridge_service }}"
     enabled: yes
 
 - name: Enable jicofo


### PR DESCRIPTION
The jitsi-meet debian package recently updated to use jitsi-videobridge v2, see
https://github.com/jitsi/jitsi-meet-debian-meta/pull/2

This causes the service name to change. Introduced a ansible var for backwards compat with older installations.