### PR TITLE
Feature/add jitsi config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,14 @@ jitsi_meet_debconf_settings:
     vtype: string
 jitsi_meet_config_resolution: 720
 jitsi_meet_config_disable_third_party_requests: "true"
+jitsi_meet_config_p2p_enabled: "true"
 # For privacy reasons we recommend to use your own STUN servers 
 jitsi_meet_config_stun_servers:
   - stun.l.google.com:19302
   - stun1.l.google.com:19302
   - stun2.l.google.com:19302
 jitsi_meet_config_default_language: en
+jitsi_meet_config_last_n: "-1"
 
 ```
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -32,6 +32,7 @@ jitsi_meet_debconf_settings:
     vtype: string
 jitsi_meet_config_resolution: 720
 jitsi_meet_config_disable_third_party_requests: "true"
+jitsi_meet_config_p2p_enabled: "true"
 jitsi_meet_config_stun_servers:
   - stun:meet-jit-si-turnrelay.jitsi.net:443
 jitsi_meet_config_default_language: en

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,10 +9,10 @@ jitsi_meet_jicofo_secret: "CHANGEME2"
 jitsi_meet_jicofo_port: 5347
 jitsi_meet_jicofo_password: "CHANGEME3"
 
-jitsi_meet_cert_choice: "Generate a new self-signed certificate (You will later get a chance to obtain a Let's encrypt certificate)"
 jitsi_meet_ssl_cert_path: "/etc/ssl/certs/ssl-cert-snakeoil.pem"
 jitsi_meet_ssl_key_path: "/etc/ssl/private/ssl-cert-snakeoil.key"
 
+jitsi_meet_cert_choice: "Generate a new self-signed certificate (You will later get a chance to obtain a Let's encrypt certificate)"
 jitsi_meet_debconf_settings:
   - name: jitsi-meet
     question: jitsi-meet/cert-choice
@@ -35,3 +35,4 @@ jitsi_meet_config_disable_third_party_requests: "true"
 jitsi_meet_config_stun_servers:
   - stun:meet-jit-si-turnrelay.jitsi.net:443
 jitsi_meet_config_default_language: en
+jitsi_meet_config_last_n: "-1"

--- a/templates/meet-config.js.j2
+++ b/templates/meet-config.js.j2
@@ -208,7 +208,7 @@ var config = {
     // Misc
 
     // Default value for the channel "last N" attribute. -1 for unlimited.
-    channelLastN: -1,
+    channelLastN: {{ jitsi_meet_config_last_n }},
 
     // Disables or enables RTX (RFC 4588) (defaults to false).
     // disableRtx: false,

--- a/templates/meet-config.js.j2
+++ b/templates/meet-config.js.j2
@@ -331,7 +331,7 @@ var config = {
         // through the JVB and use the peer to peer connection instead. When a
         // 3rd participant joins the conference will be moved back to the JVB
         // connection.
-        enabled: true,
+        enabled: {{ jitsi_meet_config_p2p_enabled }},
 
         // Use XEP-0215 to fetch STUN and TURN servers.
         // useStunTurn: true,


### PR DESCRIPTION
We have had some success with the `lastN` option of jitsi, in order to enable even large conferences for users in a low bandwidth situation. So this PR adds the lastN option.

Also allows to configure the default language and the possibility to disable p2p alltogether (e.g. if one does not want to setup a turn server nor use the google one).

I moved the `jitsi_meet_cert_choice` bit because i felt it makes more sense there, but i'll glady revert the change, if you disagree..