### PR TITLE
Allow to specify custom mobile download links

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -59,3 +59,6 @@ jitsi_meet_title: Jitsi Meet
 jitsi_meet_description: Join a WebRTC video conference powered by the Jitsi Videobridge
 jitsi_meet_provider_name: Jitsi
 jitsi_meet_provider_link: https://jitsi.org
+
+jitsi_meet_mobile_download_link_android: https://play.google.com/store/apps/details?id=org.jitsi.meet
+jitsi_meet_mobile_download_link_ios: https://itunes.apple.com/us/app/jitsi-meet/id1165103905

--- a/templates/interface_config.js.j2
+++ b/templates/interface_config.js.j2
@@ -223,12 +223,12 @@ var interfaceConfig = {
     /**
      * Specify custom URL for downloading android mobile app.
      */
-    // MOBILE_DOWNLOAD_LINK_ANDROID: 'https://play.google.com/store/apps/details?id=org.jitsi.meet',
+    MOBILE_DOWNLOAD_LINK_ANDROID: '{{ jitsi_meet_mobile_download_link_android }}',
 
     /**
      * Specify URL for downloading ios mobile app.
      */
-    // MOBILE_DOWNLOAD_LINK_IOS: 'https://itunes.apple.com/us/app/jitsi-meet/id1165103905',
+    MOBILE_DOWNLOAD_LINK_IOS: '{{ jitsi_meet_mobile_download_link_ios }}',
 
     /**
      * Specify mobile app scheme for opening the app from the mobile browser.


### PR DESCRIPTION
Currently the web app uses a google link, that determines your OS and forwards to Google Play/App Store