### PR TITLE
Fixes meet config template regarding deploymentUrls

### DIFF
--- a/templates/meet-config.js.j2
+++ b/templates/meet-config.js.j2
@@ -461,9 +461,8 @@ var config = {
     //    downloadAppsUrl: 'https://docs.example.com/our-apps.html'
     // },
 {% if jitsi_meet_config_deployment_urls %}
-    deploymentUrls: {
-        {{ jitsi_meet_config_deployment_urls | to_nice_json }}
-    },
+    deploymentUrls:
+        {{ jitsi_meet_config_deployment_urls | to_nice_json }},
 {% endif %}
 
     // Options related to the remote participant menu.


### PR DESCRIPTION
ciao, there were superfluous curly brackets in the config template that the json parser couldn't digest.