### PR TITLE
Introduce configurable nginx ssl settings with presets

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -57,19 +57,19 @@ jitsi_meet_jicofo_loglevel: "{{ jitsi_meet_loglevel }}"
 jitsi_meet_jicofo_logging_properties: |
   handlers= java.util.logging.ConsoleHandler
   #handlers= java.util.logging.ConsoleHandler, com.agafua.syslog.SyslogHandler
-  
+
   java.util.logging.ConsoleHandler.level = {{ jitsi_meet_jicofo_loglevel }}
   java.util.logging.ConsoleHandler.formatter = org.jitsi.utils.logging2.JitsiLogFormatter
-  
+
   net.java.sip.communicator.util.ScLogFormatter.programname=JVB
-  
+
   .level= {{ jitsi_meet_jicofo_loglevel }}
-  
+
   org.jitsi.videobridge.xmpp.ComponentImpl.level=FINE
-  
+
   # All of the INFO level logs from MediaStreamImpl are unnecessary in the context of jitsi-videobridge.
   org.jitsi.impl.neomedia.MediaStreamImpl.level=WARNING
-  
+
   # Syslog(uncomment handler to use)
   com.agafua.syslog.SyslogHandler.transport = udp
   com.agafua.syslog.SyslogHandler.facility = local0
@@ -77,10 +77,10 @@ jitsi_meet_jicofo_logging_properties: |
   com.agafua.syslog.SyslogHandler.hostname = localhost
   com.agafua.syslog.SyslogHandler.formatter = org.jitsi.utils.logging2.JitsiLogFormatter
   com.agafua.syslog.SyslogHandler.escapeNewlines = false
-  
+
   # to disable double timestamps in syslog uncomment next line
   #net.java.sip.communicator.util.ScLogFormatter.disableTimestamp=true
-  
+
   # time series logging
   java.util.logging.SimpleFormatter.format= %5$s%n
   java.util.logging.FileHandler.level = ALL
@@ -89,7 +89,7 @@ jitsi_meet_jicofo_logging_properties: |
   java.util.logging.FileHandler.limit = 200000000
   java.util.logging.FileHandler.count = 1
   java.util.logging.FileHandler.append = false
-  
+
   timeseries.level=OFF
   timeseries.org.jitsi.videobridge.cc.vp8.level=ALL
   timeseries.useParentHandlers = false
@@ -98,3 +98,20 @@ jitsi_meet_jicofo_logging_properties: |
 # Disable nginx access log per default
 jitsi_meet_nginx_access_log: "off"
 jitsi_meet_nginx_error_log: /var/log/nginx/error.log
+jitsi_meet_nginx_ssl_preset: "intermediate"
+jitsi_meet_nginx_ssl_presets:
+  modern:
+    protocols: TLSv1.3
+    ciphers: ""
+    prefer_server_ciphers: "off"
+  intermediate:
+    protocols: TLSv1.2 TLSv1.3
+    ciphers: ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384
+    prefer_server_ciphers: "off"
+  old:
+    protocols: TLSv1 TLSv1.1 TLSv1.2 TLSv1.3
+    ciphers: ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES256-SHA256:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA
+    prefer_server_ciphers: "on"
+jitsi_meet_nginx_ssl_protocols: "{{ jitsi_meet_nginx_ssl_presets[jitsi_meet_nginx_ssl_preset]['protocols'] }}"
+jitsi_meet_nginx_ssl_prefer_server_ciphers: "{{ jitsi_meet_nginx_ssl_presets[jitsi_meet_nginx_ssl_preset]['prefer_server_ciphers'] }}"
+jitsi_meet_nginx_ssl_ciphers: "{{ jitsi_meet_nginx_ssl_presets[jitsi_meet_nginx_ssl_preset]['ciphers'] }}"

--- a/templates/nginx/sites-available/vhost.conf.j2
+++ b/templates/nginx/sites-available/vhost.conf.j2
@@ -24,9 +24,11 @@ server {
 {% endif %}
     server_name {{ jitsi_meet_server_name }};
 
-    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
-    ssl_prefer_server_ciphers on;
-    ssl_ciphers "EECDH+ECDSA+AESGCM:EECDH+aRSA+AESGCM:EECDH+ECDSA+SHA256:EECDH+aRSA+SHA256:EECDH+ECDSA+SHA384:EECDH+ECDSA+SHA256:EECDH+aRSA+SHA384:EDH+aRSA+AESGCM:EDH+aRSA+SHA256:EDH+aRSA:EECDH:!aNULL:!eNULL:!MEDIUM:!LOW:!3DES:!MD5:!EXP:!PSK:!SRP:!DSS:!RC4:!SEED";
+    ssl_protocols {{ jitsi_meet_nginx_ssl_protocols }};
+    ssl_prefer_server_ciphers {{ jitsi_meet_nginx_ssl_prefer_server_ciphers }};
+    {% if not jitsi_meet_nginx_ssl_ciphers == "" %}
+    ssl_ciphers "{{ jitsi_meet_nginx_ssl_ciphers }}";
+    {% endif %}
 
     {% if (jitsi_meet_ssl_cert_path == '' and jitsi_meet_ssl_key_path == '') %}#{% endif %}add_header Strict-Transport-Security "max-age=31536000";
 


### PR DESCRIPTION
This PR adds the option to configure ssl settings in nginx with some presets. This is inspired by spantaleev/matrix-docker-ansible-deploy#755. 

Defaults taken from https://wiki.mozilla.org/Security/Server_Side_TLS#Recommended_configurations

## New variables

```yaml
jitsi_meet_nginx_ssl_preset: "intermediate"
jitsi_meet_nginx_ssl_presets:
  modern:
    protocols: TLSv1.3
    ciphers: ""
    prefer_server_ciphers: "off"
  intermediate:
    protocols: TLSv1.2 TLSv1.3
    ciphers: ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384
    prefer_server_ciphers: "off"
  old:
    protocols: TLSv1 TLSv1.1 TLSv1.2 TLSv1.3
    ciphers: ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES256-SHA256:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA
    prefer_server_ciphers: "on"
jitsi_meet_nginx_ssl_protocols: "{{ jitsi_meet_nginx_ssl_presets[jitsi_meet_nginx_ssl_preset]['protocols'] }}"
jitsi_meet_nginx_ssl_prefer_server_ciphers: "{{ jitsi_meet_nginx_ssl_presets[jitsi_meet_nginx_ssl_preset]['prefer_server_ciphers'] }}"
jitsi_meet_nginx_ssl_ciphers: "{{ jitsi_meet_nginx_ssl_presets[jitsi_meet_nginx_ssl_preset]['ciphers'] }}"
```