### PR TITLE
fix default stun server

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -34,7 +34,7 @@ jitsi_meet_config_constraints:
       min: 240
 jitsi_meet_config_start_audio_only: "false"
 jitsi_meet_config_stun_servers:
-  - stun:meet-jit-si-turnrelay.jitsi.net:443
+  - meet-jit-si-turnrelay.jitsi.net:443
 
 # Jitsi Meet global variables
 


### PR DESCRIPTION
When pulling your upstream changes, i noticed that the default STUN / TURN server is wrong. This is just a quick fix, so the default doesn't mislead others.