### PR TITLE
Add config options for running behind proxies and with NAT

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -135,3 +135,10 @@ jitsi_meet_nginx_ssl_protocols: "{{ jitsi_meet_nginx_ssl_presets[jitsi_meet_ngin
 jitsi_meet_nginx_ssl_prefer_server_ciphers: "{{ jitsi_meet_nginx_ssl_presets[jitsi_meet_nginx_ssl_preset]['prefer_server_ciphers'] }}"
 jitsi_meet_nginx_ssl_ciphers: "{{ jitsi_meet_nginx_ssl_presets[jitsi_meet_nginx_ssl_preset]['ciphers'] }}"
 jitsi_meet_nginx_ssl_dhparam: "/etc/nginx/dhparam"
+
+# If you are behind a proxy that does SSL termination set this to false
+jitsi_meet_nginx_listen_https_enabled: true
+
+# You need to set both jitsi_meet_nat_local_ip and jitsi_meet_nat_public_ip if you enable NAT
+jitsi_meet_behind_nat_enabled: false
+jitsi_meet_nat_local_ip: "{{ ansible_default_ipv4.address }}"

--- a/templates/nginx/sites-available/vhost.conf.j2
+++ b/templates/nginx/sites-available/vhost.conf.j2
@@ -11,6 +11,7 @@ server {
     location = /.well-known/acme-challenge/ {
        return 404;
     }
+{% if jitsi_meet_nginx_listen_https_enabled %}
     location / {
        return 301 https://$host$request_uri;
     }
@@ -18,7 +19,6 @@ server {
 server {
     listen 443 ssl http2;
     listen [::]:443 ssl http2;
-    server_name {{ jitsi_meet_server_name }};
 
     ssl_protocols {{ jitsi_meet_nginx_ssl_protocols }};
     ssl_prefer_server_ciphers {{ jitsi_meet_nginx_ssl_prefer_server_ciphers }};
@@ -40,6 +40,9 @@ server {
     ssl_stapling_verify on;
 
     add_header Strict-Transport-Security "max-age=31536000";
+{% endif %}
+
+    server_name {{ jitsi_meet_server_name }};
 
     root /usr/share/jitsi-meet;
 

--- a/templates/videobridge/sip-communicator.properties.j2
+++ b/templates/videobridge/sip-communicator.properties.j2
@@ -1,5 +1,9 @@
 org.ice4j.ice.harvest.DISABLE_AWS_HARVESTER=true
 org.ice4j.ice.harvest.STUN_MAPPING_HARVESTER_ADDRESSES={{ jitsi_meet_config_stun_servers[0] }}
+{% if jitsi_meet_behind_nat_enabled %}
+org.ice4j.ice.harvest.NAT_HARVESTER_LOCAL_ADDRESS="{{ jitsi_meet_nat_local_ip }}"
+org.ice4j.ice.harvest.NAT_HARVESTER_PUBLIC_ADDRESS="{{ jitsi_meet_nat_public_ip }}"
+{% endif %}
 org.jitsi.videobridge.ENABLE_STATISTICS=true
 org.jitsi.videobridge.STATISTICS_TRANSPORT=muc
 org.jitsi.videobridge.xmpp.user.shard.HOSTNAME=localhost


### PR DESCRIPTION
This adds config options to allow for operation in a NAT'ed environment with a proxy that does SSL termination at the network border.