### PR TITLE
Add mime type mapping for wave files

### DIFF
--- a/templates/nginx/sites-available/vhost.conf.j2
+++ b/templates/nginx/sites-available/vhost.conf.j2
@@ -2,8 +2,9 @@
 server_names_hash_bucket_size 64;
 
 types {
-# nginx's default mime.types doesn't include a mapping for wasm
+# nginx's default mime.types doesn't include a mapping for wasm or wav.
     application/wasm     wasm;
+    audio/wav            wav;
 }
 server {
     listen 80;


### PR DESCRIPTION
This incorporates the changes of https://github.com/jitsi/jitsi-meet/pull/11863 into this role.

Firefox (and maybe other browsers) would not play notification sounds because the wav files were served with the wrong mime type.