### PR TITLE
Prosody: drop polls

### DIFF
--- a/templates/prosody/conf.avail/virtualhost.cfg.lua.j2
+++ b/templates/prosody/conf.avail/virtualhost.cfg.lua.j2
@@ -82,7 +82,6 @@ Component "conference.{{ jitsi_meet_server_name }}" "muc"
     modules_enabled = {
         "muc_meeting_id";
         "muc_domain_mapper";
-        "polls";
         --"token_verification";
         "muc_rate_limit";
     }
@@ -146,7 +145,6 @@ Component "lobby.{{ jitsi_meet_server_name }}" "muc"
     muc_room_default_public_jids = true
     modules_enabled = {
         "muc_rate_limit";
-        "polls";
     }
 
 Component "metadata.{{ jitsi_meet_server_name }}" "room_metadata_component"


### PR DESCRIPTION
Upstream dropped this recently as well, and made it available as a component.

https://github.com/jitsi/jitsi-meet/commit/469406d7cd9fbf4ffa72f3a2e3cb017115690866