### PR TITLE
systemd: make jicofo and jvb part of prosody

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,7 @@ jitsi_meet_dependencies:
   - apt-utils
   - lua5.2
   - lua-unbound
+  - netcat-openbsd
 
 jitsi_meet_packages:
   - jitsi-meet

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -14,6 +14,10 @@
     name: nginx
     state: restarted
 
+- name: Reload systemd
+  ansible.builtin.systemd:
+    daemon_reload: true
+
 - name: Restart jitsi-videobridge2
   ansible.builtin.service:
     name: jitsi-videobridge2

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -5,6 +5,7 @@
   roles:
     - role: systemli.jitsi_meet
   vars:
+    is_molecule_test: true
     jitsi_meet_base_secret: my_very_own_secret
     jitsi_meet_server_name: jitsi-meet.example.org
     jitsi_meet_nat_local_ip: 127.0.0.1

--- a/tasks/jitsi-meet.yml
+++ b/tasks/jitsi-meet.yml
@@ -72,5 +72,40 @@
     name: jicofo
     enabled: yes
 
+- name: Create systemd override directories
+  ansible.builtin.file:
+    group: root
+    mode: "0755"
+    owner: root
+    path: "/etc/systemd/system/{{ item }}.service.d"
+    state: directory
+  loop:
+    - jicofo
+    - jitsi-videobridge2
+
+- name: Install systemd overrides
+  ansible.builtin.copy:
+    content: |
+      [Unit]
+      After=prosody.service
+      PartOf=prosody.service
+
+      [Service]
+      # Check if prosody is up and running, as both jicofo and jitsi-videobridge2 require it.
+      ExecStartPre=/bin/bash -c 'until /usr/bin/nc -w 2 -z 127.0.0.1 5222; do sleep 2; done'
+    dest: "/etc/systemd/system/{{ item }}.service.d/override.conf"
+    group: root
+    mode: "0644"
+    owner: root
+  loop:
+    - jicofo
+    - jitsi-videobridge2
+  notify:
+    - Reload systemd
+    - Restart jicofo
+    - Restart jitsi-videobridge2
+  # Don't install systemd overrides if tests are done via molecule
+  when: not (is_molecule_test | default(false) | bool)
+
 - name: Flush handlers
   ansible.builtin.meta: flush_handlers


### PR DESCRIPTION
jicofo and jvb require prosody to be up and running. This change tells systemd about this relationship.

Besides, before start, both services check that prosody is indeed reachable.